### PR TITLE
Tighten up handling of failure of type lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 blib/*
+.precomp

--- a/lib/Hiker.pm6
+++ b/lib/Hiker.pm6
@@ -29,7 +29,7 @@ class Hiker {
     my $recurse = sub (*@m) {
       my @r;
       for @m -> $m {
-        @r.append($m) unless @ignore.grep($m) || ::($m.^name) !~~ any(Hiker::Route, Hiker::Model);
+        @r.append($m) unless @ignore.grep($m) || (::($m.^name) && ::($m.^name) !~~ any(Hiker::Route, Hiker::Model));
         try @r.append($recurse($m.WHO.values)) if $m.WHO.values.elems;
       }
       return @r.flat;

--- a/lib/Hiker/Render.pm6
+++ b/lib/Hiker/Render.pm6
@@ -9,7 +9,7 @@ role Hiker::Render {
   has %.data;
 
   method render(:$file? = $.template) {
-    if !$file:defined || $file.IO !~~ :f {
+    if !$file.defined || $file.IO !~~ :f {
       $.close('404');
     }
     $.close($renderer.render($file.IO.slurp, %.data));


### PR DESCRIPTION
This was leading to confusing errors

```
WARNING: unhandled Failure detected in DESTROY:
No such symbol 'Template::Mustache::Template::Mustache::Grammar'
  in sub  at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 32
  in block  at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 33
  in sub  at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 31
  in block  at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 33
  in sub  at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 31
  in method bind at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 39
  in submethod BUILD at /usr/share/perl6/site/sources/239978CDDC55BCF8072D73AD4AB9CAAEB70354CF (Hiker) line 21
  in block <unit> at index.p6 line 5
```

It appears to pass it's tests now :)
