### PR TITLE
Fix trouble with multiple models

### DIFF
--- a/lib/Hiker.pm6
+++ b/lib/Hiker.pm6
@@ -91,7 +91,7 @@ class Hiker {
           my $model;
           try {
             CATCH { default { warn $_; } }
-            $model = .values.grep({ .^name eq ( $obj.^can('model') ?? $obj.model !! '' ) })[0].new 
+            $model //= .values.grep({ .^name eq ( $obj.^can('model') ?? $obj.model !! '' ) })[0].new 
               for @models;
           }
           route $obj.path, sub ($req, $res) {


### PR DESCRIPTION
Having more than one model does not work properly because this line overwrites the `$model` var for every value in `@models`.
This change makes it check if it got a valid result before saving to `$model`.